### PR TITLE
Remove Topaz

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -71,7 +71,7 @@ $_documentContainer.innerHTML = `<custom-style>
 					background-color: var(--d2l-color-citrine-plus-1);
 				}
 				d2l-scroll-point[key="pt2"] {
-					background-color: var(--d2l-color-topaz-plus-1);
+					background-color: var(--d2l-color-citrine);
 				}
 				d2l-scroll-point[key="pt3"] {
 					background-color: var(--d2l-color-cinnabar-plus-2);


### PR DESCRIPTION
Remove topaz from the demo since this is its only use and it was removed from the color palette with the WCAG 2.1 color updates.